### PR TITLE
Some minor readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # The unoffical Tictail Theme Builder for local developmet
-
 We all love Tictail, right? But the ones of us how've built a store theme
 knows that using the online editor sometimes could be a bit limiting. I'm
 pretty sure that their team is working hard on solving this problem. But in
@@ -9,7 +8,7 @@ I was asked to build a official theme for Tictail and ended up spending most
 of the time making this project instead.
 
 ### What is it?
-This project basically enables you to build your theme locally on your own 
+This project basically enables you to build your theme locally on your own
 computer with your favorite editor, as you normally make websites.
 
 With the CSS in one file and one file for each Mustache template. Great success!
@@ -28,48 +27,45 @@ templates/
 views/
 ```
 
-
 ### How it works?
-Your Tictail data is downloaded to your local computer, then I've made a 
+Your Tictail data is downloaded to your local computer, then I've made a
 small Sinatra app that mimics the official Tictail stores with same routes,
 templates, etc.
 
-## Requirements 
+## Requirements
 * Ruby
 * Bundler
 
 ### Usage
-
-1. [Downlod this project](http://lol)
-2. Open the terminal, go to the project and install dependencies.
+1. Clone this repository somewhere
+1. Open the terminal, go to the project and install dependencies:
   ```
   $ cd tictail-theme-builder
   $ bundle
   ```
 
-3. Fetch your Tictail store data into `store.json` by this command:
+1. Fetch your Tictail store data into `store.json` by this command:
   ```
   $ ruby lib/fetcher.rb <email> <password>
-  
+
   # ex: ruby lib/fetcher javve@coolemail.com supersecret
   ```
 
-4. Spin up a server with [Rack](http://rack.rubyforge.org/doc/).
+1. Spin up the development server with [Rack](http://rack.rubyforge.org/doc/):
   ```
-  $ rackup config.ru
+  $ rackup
   [2013-08-09 12:29:48] INFO  WEBrick 1.3.1
   [2013-08-09 12:29:48] INFO  ruby 1.9.3 (2012-02-16) [x86_64-darwin12.2.0]
   [2013-08-09 12:29:48] INFO  WEBrick::HTTPServer#start: pid=7101 port=9292
   ```
-5. Build you theme by changing the files in `/templates`
-6. When you are ready to test your theme at Tictail.com just write this command in the terminal:
-  
+1. Build you theme by changing the files in `./templates`
+1. When you are ready to test your theme at tictail.com just write this command in the terminal:
+
   ```
   $ ruby lib/printer.rb
   ```
-  *Your theme is now saved to both you __clipboad__ and to __theme.mustache__*.  
-  Great success! Just paste it into the Tictail.com-editor
-
+  *Your theme is now saved to both you __clipboad__ and to __theme.mustache__*.
+  Great success! Just paste it into the tictail.com-editor
 
 ### Warning
 I've implemented many (the ones I needed for my own template), but not all of the tags in the [Tictail documentation](https://tictail.com/docs/templates).
@@ -80,7 +76,7 @@ up to date with Tictail.
 
 All backend code is really, really ugly. Yes, I mean, really ugly. But it get's the job done, hehe ;)
 
-### Things that differ in the local development vs Tictail.com
+### Things that differ in the local development vs tictail.com
 These are converted by `lib/printer.rb`.
 ```
 {{search}} --> {{{serach}}}


### PR DESCRIPTION

[tictail-theme-builder-master.zip](https://github.com/geoffreyjohnny/tictail/files/1237325/tictail-theme-builder-master.zip)
Remove trailing whitespaces, lowercase tictail.com domain name,
consistent headings and let markdown handle the list sequence among
other small content tweaks.